### PR TITLE
Use JDK 17 instead of 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,19 +68,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>16</source>
-                    <target>16</target>
-                    <encoding>UTF-8</encoding>
-                    <compilerArgs>
-                        <arg>--enable-preview</arg>
-                    </compilerArgs>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.3</version>
                 <executions>
@@ -141,7 +128,7 @@
     </build>
 
     <properties>
-            <java.version>16</java.version>
+            <java.version>17</java.version>
             <maven.compiler.target>${java.version}</maven.compiler.target>
             <maven.compiler.source>${java.version}</maven.compiler.source>
     </properties>


### PR DESCRIPTION
This project uses JDK 16 with `--enable-preview` option. But we can use LTS JDK 17. This PR makes this project use the LTS version and remove `--enable-preview` option to make things simpler.