### PR TITLE
Use JDK 17 to fix CI failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: 16
+          java-version: 17
       - name: Build with Maven
         run: ./mvnw test --file pom.xml


### PR DESCRIPTION
I noticed my merged PR caused this CI failure https://github.com/toys-lang/toys/actions/runs/6136489197. I think the CI also needs to use JDK 17. This PR tries to fix the issue.